### PR TITLE
Separate branch for validators and new filter functions

### DIFF
--- a/src/Bridge/FormBridgeAbstract.php
+++ b/src/Bridge/FormBridgeAbstract.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Zalt\Model\Bridge;
 
+use Laminas\Validator\StringLength;
 use Zalt\Late\Late;
 use Zalt\Late\LateCall;
 use Zalt\Late\RepeatableInterface;
@@ -76,6 +77,8 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
     public $defaultSize = 40;
 
     public MetaModelInterface $metaModel;
+
+    public ValidatorBridgeInterface $validatorBridge;
     
     /**
      * @inheritDoc
@@ -86,6 +89,7 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
             throw new MetaModelException("Only FullDataInterface objects are allowed as input for a FormBridge");
         }
         $this->metaModel = $this->dataModel->getMetaModel();
+        $this->validatorBridge = $this->getValidatorBridge();
     }
 
     /**
@@ -440,12 +444,6 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
             self::TEXT_OPTIONS
         );
 
-        $stringlength = $this->_getStringLength($options);
-
-        if ($stringlength) {
-            $this->metaModel->set($name, 'validators[]', array('StringLength', true, $stringlength));
-        }
-
         return $this->_addToForm($name, 'Text', $options);
     }
 
@@ -455,14 +453,6 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
         $options = Ra::pairs($options, 1);
 
         $options = $this->_mergeOptions($name, $options,self::DISPLAY_OPTIONS, self::TEXT_OPTIONS, self::TEXTAREA_OPTIONS);
-
-        $stringlength = $this->_getStringLength($options);
-        // Remove as size and maxlength are not used for textarea's
-        unset($options['size'], $options['maxlength']);
-
-        if ($stringlength) {
-            $this->metaModel->set($name, 'validators[]', array('StringLength', true, $stringlength));
-        }
 
         return $this->_addToForm($name, 'Textarea', $options);
     }
@@ -536,6 +526,8 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
     {
         return $this->dataModel->loadFirst();
     }
+
+    abstract public function getValidatorBridge(): ValidatorBridgeInterface;
 
     /**
      * @inheritDoc

--- a/src/Bridge/Laminas/LaminasValidatorBridge.php
+++ b/src/Bridge/Laminas/LaminasValidatorBridge.php
@@ -1,0 +1,464 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Bridge\Laminas
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Bridge\Laminas;
+
+use Laminas\Validator\Digits;
+use Laminas\Validator\File\Count;
+use Laminas\Validator\File\Extension;
+use Laminas\Validator\File\Size;
+use Laminas\Validator\StringLength;
+use Laminas\Validator\ValidatorInterface;
+use MUtil\Validator\IsConfirmed;
+use Zalt\Loader\ProjectOverloader;
+use Zalt\Model\Bridge\ValidatorBridgeInterface;
+use Zalt\Model\Data\DataReaderInterface;
+use Zalt\Model\Data\FullDataInterface;
+use Zalt\Model\Exception\MetaModelException;
+use Zalt\Model\Exception\ModelValidatorLoadException;
+use Zalt\Model\MetaModelInterface;
+use Zalt\Model\Validator\ModelAwareValidatorInterface;
+use Zalt\Model\Validator\NameAwareValidatorInterface;
+
+/**
+ * A validator added can be added as a:
+ *
+ * - A single class name
+ * - An array of [string: className, bool breakChainOnFailure, array options]
+ * - An instantiated object implementing the Laminas ValidatorInterface
+ *
+ * @package    Zalt
+ * @subpackage Model\Bridge\Laminas
+ * @since      Class available since version 1.0
+ */
+class LaminasValidatorBridge extends \Zalt\Model\Bridge\BridgeAbstract implements ValidatorBridgeInterface
+{
+    /**
+     * @var array elementClassName => compile function
+     */
+    protected array $_elementClassCompilers = [];
+
+    /**
+     * @var array typeIdentifyer => compile function
+     */
+    protected array $_typeClassCompilers = [];
+
+    /**
+     * @var array name => array of validators
+     */
+    protected array $_loadedValidators = [];
+
+    /**
+     * @var array Used by LaminasValidatorLoaderTrait copied functions
+     */
+    protected array $_validators;
+
+    /**
+     * When no size is set for a text-element, the size will be set to the minimum of the
+     * maxsize and this value.
+     *
+     * @var int
+     */
+    public $defaultTextSize = 40;
+
+    protected ProjectOverloader $validatorOverloader;
+
+    public function __construct(DataReaderInterface $dataModel, ProjectOverloader $projectOverloader = null)
+    {
+        parent::__construct($dataModel);
+
+        if (! $this->dataModel instanceof FullDataInterface) {
+            throw new MetaModelException("Only FullDataInterface objects are allowed as input for a " . __CLASS__ . " constructor");
+        }
+
+        if (! $projectOverloader instanceof ProjectOverloader) {
+            throw new MetaModelException("A ProjectOverloader objects is required as input for a " . __CLASS__ . " constructor");
+        }
+
+        $this->validatorOverloader = $projectOverloader->createSubFolderOverloader('Validator');
+        $this->validatorOverloader->legacyClasses = false;
+
+        $this->loadDefaultElementCompilers();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _compile(string $name): array
+    {
+        return $this->getValidatorsFor($name);
+    }
+
+    /**
+     * Lazy-load a validator
+     *
+     * @param  array $validator Validator definition
+     * @return Zend_Validate_Interface
+     */
+    protected function _loadValidator(array $validator): ValidatorInterface
+    {
+        $origName = $validator['validator'];
+        $name     = $this->validatorOverloader->find($validator['validator']);
+
+        $messages = false;
+        if (isset($validator['options']) && array_key_exists('messages', (array) $validator['options'])) {
+            $messages = $validator['options']['messages'];
+            unset($validator['options']['messages']);
+        }
+
+        if (empty($validator['options'])) {
+            $instance = new $name;
+        } else {
+            $r = new \ReflectionClass($name);
+            if ($r->hasMethod('__construct')) {
+                $numeric = false;
+                if (is_array($validator['options'])) {
+                    $keys    = array_keys($validator['options']);
+                    foreach($keys as $key) {
+                        if (is_numeric($key)) {
+                            $numeric = true;
+                            break;
+                        }
+                    }
+                }
+
+                if ($numeric) {
+                    $instance = $r->newInstanceArgs((array) $validator['options']);
+                } else {
+                    $instance = $r->newInstance($validator['options']);
+                }
+            } else {
+                $instance = $r->newInstance();
+            }
+        }
+
+        if ($messages) {
+            if (is_array($messages)) {
+                $instance->setMessages($messages);
+            } elseif (is_string($messages)) {
+                $instance->setMessage($messages);
+            }
+        }
+        $instance->zfBreakChainOnFailure = $validator['breakChainOnFailure'];
+
+        return $instance;
+    }
+
+    /**
+     * Add validator to validation chain
+     *
+     * Note: will overwrite existing validators if they are of the same class.
+     *
+     * @param  string|ValidatorInterface $validator
+     * @param  bool $breakChainOnFailure
+     * @param  array $options
+     * @return self
+     * @throws \Zend_Form_Exception if invalid validator type
+     */
+    public function addValidator($validator, $breakChainOnFailure = false, $options = [])
+    {
+        if ($validator instanceof ValidatorInterface) {
+            $name = get_class($validator);
+        } elseif (is_string($validator)) {
+            $name      = $validator;
+            $validator = [
+                'validator' => $validator,
+                'breakChainOnFailure' => $breakChainOnFailure,
+                'options'             => $options,
+            ];
+        } else {
+            throw new ModelValidatorLoadException('Invalid validator provided to addValidator; must be string or \\Laminas\\Validator\\ValidatorInterface');
+        }
+
+        $this->_validators[$name] = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Add multiple validators
+     *
+     * @param  array $validators
+     * @return array $validators but processed
+     */
+    public function _addValidators(array $validators)
+    {
+        foreach ($validators as $validatorInfo) {
+            if (is_string($validatorInfo)) {
+                $this->addValidator($validatorInfo);
+            } elseif ($validatorInfo instanceof ValidatorInterface) {
+                $this->addValidator($validatorInfo);
+            } elseif (is_array($validatorInfo)) {
+                $argc                = count($validatorInfo);
+                $breakChainOnFailure = false;
+                $options             = [];
+                if (isset($validatorInfo['validator'])) {
+                    $validator = $validatorInfo['validator'];
+                    if (isset($validatorInfo['breakChainOnFailure'])) {
+                        $breakChainOnFailure = $validatorInfo['breakChainOnFailure'];
+                    }
+                    if (isset($validatorInfo['options'])) {
+                        $options = $validatorInfo['options'];
+                    }
+                    $this->addValidator($validator, $breakChainOnFailure, $options);
+                } else {
+                    switch (true) {
+                        case (0 == $argc):
+                            break;
+                        case (1 <= $argc):
+                            $validator  = array_shift($validatorInfo);
+                        case (2 <= $argc):
+                            $breakChainOnFailure = array_shift($validatorInfo);
+                        case (3 <= $argc):
+                            $options = array_shift($validatorInfo);
+                        default:
+                            $this->addValidator($validator, $breakChainOnFailure, $options);
+                            break;
+                    }
+                }
+            } else {
+                throw new ModelValidatorLoadException('Invalid validator passed to addValidators() ' . get_class($validatorInfo));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Retrieve all validators for an element
+     *
+     * @param string $name
+     * @return array validator name => validator or array for loading
+     */
+    public function gatherValidatorsFor(string $name): array
+    {
+        $validators = $this->metaModel->get($name, 'validators') ?? [];
+
+        if ($validator = $this->metaModel->get($name, 'validator')) {
+            if ($validators) {
+                array_unshift($validators, $validator);
+            } else {
+                $validators = array($validator);
+            }
+        }
+
+        if ($this->metaModel->get($name, 'ignoreElementValidators')) {
+            $elementClass = $this->getElementClassFor($name);
+            if (isset($this->_elementClassCompilers[$elementClass])) {
+                $validators += call_user_func($this->_elementClassCompilers[$elementClass], $this->metaModel, $name);
+            }
+        }
+        if ($this->metaModel->get($name, 'ignoreTypeValidators')) {
+            $typeId = $this->metaModel->get($name, 'type');
+            if ($typeId && isset($this->_typeClassCompilers[$typeId])) {
+                $validators += call_user_func($this->_typeClassCompilers[$typeId], $this->metaModel, $name);
+            }
+        }
+
+        return $validators;
+    }
+
+    public function getElementClassFor(string $name): string
+    {
+        if ($this->metaModel->has($name, 'elementClass')) {
+            return $this->metaModel->get($name, 'elementClass');
+        }
+        if ($this->metaModel->has($name, 'label')) {
+            if ($this->metaModel->has('multiOptions')) {
+                return 'Select';
+            }
+            return 'Text';
+        }
+        return 'Hidden';
+    }
+
+    /**
+     * @param MetaModelInterface $metaModel
+     * @param string $name
+     * @return array
+     * /
+    public function getElementValidatorsFile(MetaModelInterface $metaModel, string $name): array
+    {
+        $output = [];
+
+        $filename = $metaModel->get($name, 'filename');
+        if ($filename) {
+            $count = 1;
+        } else {
+            $count = $metaModel->get($name, 'count');
+        }
+        if ($count) {
+            $output[Count::class] = [Count::class, false, ['max' => $count]];
+        }
+
+        $size = $metaModel->get($name, 'size');
+        if ($size) {
+            $output[Size::class] = [Size::class, false, ['max' => $size]];
+        }
+
+        $extension = $metaModel->get($name, 'extension');
+        if ($extension) {
+            $output[Extension::class] = [Extension::class, false, [
+                'extension' => $extension,
+                'messages'  => [Extension::FALSE_EXTENSION => 'Only %extension% files are accepted.'],
+            ]];
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param MetaModelInterface $metaModel
+     * @param string $name
+     * @return array
+     */
+    public function getElementValidatorsPassword(MetaModelInterface $metaModel, string $name): array
+    {
+        $output = $this->getElementValidatorsText($metaModel, $name);
+
+        $confirmWith = $metaModel->get($name, 'confirmWith');
+        if ($confirmWith) {
+            $label = $metaModel->getWithDefault($confirmWith, 'label', null);
+            $output['IsConfirmed'] = ['IsConfirmed', false, [$confirmWith, $label]];
+        }
+
+        return $output;
+    }
+
+    public function getElementValidatorsText(MetaModelInterface $metaModel, string $name): array
+    {
+        $output = [];
+
+        $stringlength = [];
+        if ($metaModel->has($name, 'minlength')) {
+            $stringlength['min'] = intval($metaModel->get($name, 'minlength'));
+        }
+        if ($metaModel->has($name,'maxlength')) {
+            $stringlength['max'] = intval($metaModel->get($name,'maxlength'));
+            if (! $metaModel->has($name,'size')) {
+                $metaModel->set($name, 'size', min($stringlength['max'], $this->defaultTextSize));
+            }
+
+        } elseif ($metaModel->has($name,'size')) {
+            $stringlength['maxlength'] = $metaModel->get($name, 'size');
+        }
+        if ($stringlength) {
+            $output[StringLength::class] = [StringLength::class, false, $stringlength];
+        }
+
+        return $output;
+    }
+
+    public function getElementValidatorsTextarea(MetaModelInterface $metaModel, string $name): array
+    {
+        $output = [];
+
+        if ($metaModel->has($name, 'minlength')) {
+            $output[StringLength::class] = [StringLength::class, false, [
+                'min' => intval($metaModel->get($name, 'minlength')),
+                ]];
+        }
+
+        return $output;
+    }
+
+    public function getTypeValidatorsNumeric(MetaModelInterface $metaModel, string $name): array
+    {
+        $output = [];
+
+        $decimals = $metaModel->getWithDefault($name, 'decimals', 0);
+        if ($metaModel->get($name, 'unsigned')) {
+            if ($decimals) {
+            } else {
+                $output['Digits'] = [Digits::class];
+            }
+        } else {
+
+        }
+
+        return $output;
+    }
+
+    /**
+     * Retrieve all validators for an element
+     *
+     * @param string $name
+     * @return array
+     */
+    public function getValidatorsFor(string $name): array
+    {
+        if (isset($this->_loadedValidators[$name])) {
+            return $this->_loadedValidators[$name];
+        }
+
+        $validators = $this->gatherValidatorsFor($name);
+
+        $this->_loadedValidators[$name] = $this->loadValidators($name, $validators);
+
+        return $this->_loadedValidators[$name];
+    }
+
+    protected function loadDefaultElementCompilers()
+    {
+        // $this->setElementClassCompiler('File', [$this, 'getElementValidatorsFile'])
+        $this->setElementClassCompiler('Password', [$this, 'getElementValidatorsPassword'])
+            ->setElementClassCompiler('Text', [$this, 'getElementValidatorsText'])
+            ->setElementClassCompiler('Textarea', [$this, 'getElementValidatorsTextarea']);
+    }
+
+    protected function loadDefaultTypeCompilers()
+    {
+        $this->setTypeClassCompiler(MetaModelInterface::TYPE_NUMERIC, [$this, 'getTypeValidatorsNumeric']);
+    }
+
+    protected function loadValidators(string $name, array $validators)
+    {
+        $output = [];
+        if ($validators) {
+            $this->_validators = [];
+            $this->_addValidators($validators);
+
+            foreach ($this->_validators as $key => $value) {
+                if ($value instanceof ValidatorInterface) {
+                    $output[$key] = $value;
+                } else {
+                    $output[$key] = $this->_loadValidator($value);
+                }
+
+                if ($output[$key] instanceof NameAwareValidatorInterface) {
+                    $output[$key]->setName($name);
+                }
+                if ($output[$key] instanceof ModelAwareValidatorInterface) {
+                    $output[$key]->setDataModel($this->dataModel);
+                }
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setElementClassCompiler(string $elementClassName, callable $callable): ValidatorBridgeInterface
+    {
+        $this->_elementClassCompilers[$elementClassName] = $callable;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setTypeClassCompiler(int $typeId, callable $callable): ValidatorBridgeInterface
+    {
+        $this->_typeClassCompilers[$typeId] = $callable;
+        return $this;
+    }
+}

--- a/src/Bridge/Laminas/LaminasValidatorLoaderTrait.php
+++ b/src/Bridge/Laminas/LaminasValidatorLoaderTrait.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Bridge\Laminas
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Bridge\Laminas;
+
+use Laminas\Validator\ValidatorInterface;
+use Zalt\Model\Exception\ModelValidatorLoadException;
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Bridge\Laminas
+ * @since      Class available since version 1.0
+ */
+trait LaminasValidatorLoaderTrait
+{
+    /**
+     * Add validator to validation chain
+     *
+     * Note: will overwrite existing validators if they are of the same class.
+     *
+     * @param  string|ValidatorInterface $validator
+     * @param  bool $breakChainOnFailure
+     * @param  array $options
+     * @return self
+     * @throws \Zend_Form_Exception if invalid validator type
+     */
+    public function addValidator($validator, $breakChainOnFailure = false, $options = [])
+    {
+        if ($validator instanceof ValidatorInterface) {
+            $name = get_class($validator);
+        } elseif (is_string($validator)) {
+            $name      = $validator;
+            $validator = [
+                'validator' => $validator,
+                'breakChainOnFailure' => $breakChainOnFailure,
+                'options'             => $options,
+            ];
+        } else {
+            throw new ModelValidatorLoadException('Invalid validator provided to addValidator; must be string or \\Laminas\\Validator\\ValidatorInterface');
+        }
+
+        $this->_validators[$name] = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Add multiple validators
+     *
+     * @param  array $validators
+     * @return \Zend_Form_Element
+     */
+    public function addValidators(array $validators)
+    {
+        foreach ($validators as $validatorInfo) {
+            if (is_string($validatorInfo)) {
+                $this->addValidator($validatorInfo);
+            } elseif ($validatorInfo instanceof ValidatorInterface) {
+                $this->addValidator($validatorInfo);
+            } elseif (is_array($validatorInfo)) {
+                $argc                = count($validatorInfo);
+                $breakChainOnFailure = false;
+                $options             = [];
+                if (isset($validatorInfo['validator'])) {
+                    $validator = $validatorInfo['validator'];
+                    if (isset($validatorInfo['breakChainOnFailure'])) {
+                        $breakChainOnFailure = $validatorInfo['breakChainOnFailure'];
+                    }
+                    if (isset($validatorInfo['options'])) {
+                        $options = $validatorInfo['options'];
+                    }
+                    $this->addValidator($validator, $breakChainOnFailure, $options);
+                } else {
+                    switch (true) {
+                        case (0 == $argc):
+                            break;
+                        case (1 <= $argc):
+                            $validator  = array_shift($validatorInfo);
+                        case (2 <= $argc):
+                            $breakChainOnFailure = array_shift($validatorInfo);
+                        case (3 <= $argc):
+                            $options = array_shift($validatorInfo);
+                        default:
+                            $this->addValidator($validator, $breakChainOnFailure, $options);
+                            break;
+                    }
+                }
+            } else {
+                throw new ModelValidatorLoadException('Invalid validator passed to addValidators() ' . get_class($validatorInfo));
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Bridge/ValidatorBridgeInterface.php
+++ b/src/Bridge/ValidatorBridgeInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Bridge
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Bridge;
+
+/**
+ * Validator bridges create arrays of validators for meta model elements, using these settings
+ *
+ * - validator: adds this validator
+ * - validators[]: adds an array of multiple validators
+ * - ignoreElementValidators: Skip the validators from the ElementClassCompiler
+ * - ignoreTypeValidators: Skip the validators from the TypeClassCompiler
+ *
+ * What a validator consists of (or what can be created as one) depends on the implementing class.
+ *
+ * @package    Zalt
+ * @subpackage Model\Bridge
+ * @since      Class available since version 1.0
+ */
+interface ValidatorBridgeInterface extends BridgeInterface
+{
+    /**
+     * Retrieve all validators for an element
+     *
+     * @param string $name
+     * @return array
+     */
+    public function getValidatorsFor(string $name): array;
+
+    /**
+     * Set the element class validator compiler for a certain element class.
+     *
+     * @param string $elementClassName
+     * @param callable $callable with parameters (MetaModel, name) return an (empty) array of validator
+     * @return ValidatorBridgeInterface (Continuation pattern)
+     */
+    public function setElementClassCompiler(string $elementClassName, callable $callable): ValidatorBridgeInterface;
+
+    /**
+     * Set the type class validator compiler for a certain element class.
+     *
+     * @param int $typeId
+     * @param callable $callable with parameters (MetaModel, name) return an (empty) array of validator
+     * @return ValidatorBridgeInterface (Continuation pattern)
+     */
+    public function setTypeClassCompiler(int $typeId, callable $callable): ValidatorBridgeInterface;
+}

--- a/src/Exception/ModelValidatorLoadException.php
+++ b/src/Exception/ModelValidatorLoadException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Exception
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Exception;
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Exception
+ * @since      Class available since version 1.0
+ */
+class ModelValidatorLoadException extends MetaModelException
+{
+
+}

--- a/src/MetaModelInterface.php
+++ b/src/MetaModelInterface.php
@@ -39,6 +39,16 @@ interface MetaModelInterface
     const FILTER_CONTAINS = 'like';
 
     /**
+     * FIlter constant for not like statements
+     */
+    const FILTER_CONTAINS_NOT = 'not like';
+
+    /**
+     * FIlter constant for not statements
+     */
+    const FILTER_NOT = 'not';
+
+    /**
      * In order to keep the url's short and to hide any field names from
      * the user, model identifies key values by using 'id' for a single
      * key value and id1, id2, etc... for multiple keys.

--- a/src/Ra/ArrayModelAbstract.php
+++ b/src/Ra/ArrayModelAbstract.php
@@ -71,6 +71,9 @@ abstract class ArrayModelAbstract implements DataReaderInterface
                     if (isset($value[MetaModelInterface::FILTER_CONTAINS])) {
                         $result = str_contains($row[$name], $value[MetaModelInterface::FILTER_CONTAINS]);
                         $subFilter = false;
+                    } elseif (isset($value[MetaModelInterface::FILTER_CONTAINS_NOT])) {
+                        $result = ! str_contains($row[$name], $value[MetaModelInterface::FILTER_CONTAINS_NOT]);
+                        $subFilter = false;
                     }
                 } elseif (2 == count($value)) {
                     if (isset($value[MetaModelInterface::FILTER_BETWEEN_MAX], $value[MetaModelInterface::FILTER_BETWEEN_MIN])) {
@@ -80,7 +83,10 @@ abstract class ArrayModelAbstract implements DataReaderInterface
                 }
                 if ($subFilter) {
                     if (is_numeric($name)) {
-                        $result = $this->_applyFiltersToRow($row, $value, ! $logicalAnd);
+                        $result = $this->_applyFiltersToRow($row, $value, !$logicalAnd);
+                    } elseif (MetaModelInterface::FILTER_NOT == $name) {
+                        // Check here as NOT can be part of the main filter
+                        $result = ! $this->_applyFiltersToRow($row, $value, ! $logicalAnd);
                     } else {
                         $rowVal = $row[$name] ?? null;
                         $result = false;

--- a/src/Ra/ArrayModelAbstract.php
+++ b/src/Ra/ArrayModelAbstract.php
@@ -104,8 +104,13 @@ abstract class ArrayModelAbstract implements DataReaderInterface
                     // Allow literal value interpretation
                     $result = (boolean) $value;
                 } else {
-                    $val    = isset($row[$name]) ? $row[$name] : null;
-                    $result = ($val === $value) || (0 === strcasecmp($value, $val));
+                    $val = isset($row[$name]) ? $row[$name] : null;
+
+                    if (is_string($value) || is_string($val)) {
+                        $result = ($val === $value) || (0 === strcasecmp((string) $value, (string) $val));
+                    } else {
+                        $result = ($val === $value);
+                    }
                 }
                 // \MUtil\EchoOut\EchoOut::r($value . '===' . $value . '=' . $result);
             }

--- a/src/Sql/Laminas/LaminasRunner.php
+++ b/src/Sql/Laminas/LaminasRunner.php
@@ -146,6 +146,10 @@ class LaminasRunner implements \Zalt\Model\Sql\SqlRunnerInterface
                                 $output->like($name, '%' . $value[MetaModelInterface::FILTER_CONTAINS] . '%');
                                 continue;
                             }
+                            if (isset($value[MetaModelInterface::FILTER_CONTAINS_NOT])) {
+                                $output->notLike($name, '%' . $value[MetaModelInterface::FILTER_CONTAINS_NOT] . '%');
+                                continue;
+                            }
                         }
                         if (2 == count($value)) {
                             if (isset($value[MetaModelInterface::FILTER_BETWEEN_MAX], $value[MetaModelInterface::FILTER_BETWEEN_MIN])) {
@@ -153,7 +157,12 @@ class LaminasRunner implements \Zalt\Model\Sql\SqlRunnerInterface
                                 continue;
                             }
                         }
-                        if ($value) {
+                        if (MetaModelInterface::FILTER_NOT == $field) {
+                            // Check here as NOT can be part of the main filter
+                            $not = new NotPredicate([]);
+                            $not->andPredicate($this->createWhere($metaModel, $value, true));
+                            $output->addPredicate($not);
+                        } elseif ($value) {
                             $output->in($name, $value);
                         } else {
                             // Always false when no values

--- a/src/Sql/Laminas/NotPredicate.php
+++ b/src/Sql/Laminas/NotPredicate.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Sql\Laminas
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Sql\Laminas;
+
+use Laminas\Db\Sql\Predicate\PredicateInterface;
+use Laminas\Db\Sql\Predicate\PredicateSet;
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Sql\Laminas
+ * @since      Class available since version 1.0
+ */
+class NotPredicate extends \Laminas\Db\Sql\Predicate\PredicateSet
+{
+    public const COMBINED_BY_NOT = 'NOT';
+
+    public function __construct(?array $predicates = null)
+    {
+        parent::__construct($predicates, self::COMBINED_BY_AND);
+    }
+
+    public function getExpressionData()
+    {
+        $parts[] = 'NOT (';
+        $parts = array_merge($parts, parent::getExpressionData());
+        $parts[] = ')';
+        return $parts;
+    }
+}

--- a/src/Sql/SqlRunnerInterface.php
+++ b/src/Sql/SqlRunnerInterface.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Zalt\Model\Sql;
 
-use Laminas\Db\Adapter\Adapter;
-use Laminas\Db\Adapter\AdapterInterface;
 use Zalt\Model\MetaModelInterface;
 
 /**

--- a/src/Validator/ModelAwareValidatorInterface.php
+++ b/src/Validator/ModelAwareValidatorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Validate
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Validator;
+
+use Zalt\Model\Data\FullDataInterface;
+
+/**
+ * Interface to mark validators that use a data model
+ *
+ * @package    Zalt
+ * @subpackage Model\Validate
+ * @since      Class available since version 1.0
+ */
+interface ModelAwareValidatorInterface
+{
+    /**
+     * Set / apply the model
+     * @param FullDataInterface $model
+     * @return void
+     */
+    public function setDataModel(FullDataInterface $model): void;
+}

--- a/src/Validator/NameAwareValidatorInterface.php
+++ b/src/Validator/NameAwareValidatorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * @package    Zalt
+ * @subpackage Model\Validator
+ * @author     Matijs de Jong <mjong@magnafacta.nl>
+ */
+
+namespace Zalt\Model\Validator;
+
+/**
+ * Interface to mark validators that want to know the current field name
+ *
+ * @package    Zalt
+ * @subpackage Model\Validator
+ * @since      Class available since version 1.0
+ */
+interface NameAwareValidatorInterface
+{
+    /**
+     * Set the name
+     * @param string $name
+     * @return void
+     */
+    public function setName(string $name): void;
+}

--- a/test/Ra/PhpArrayTest.php
+++ b/test/Ra/PhpArrayTest.php
@@ -177,6 +177,24 @@ class PhpArrayTest extends TestCase
         $this->assertEquals([$rows[2]], $model->load(['b' => [MetaModelInterface::FILTER_CONTAINS => 'C']]));
     }
 
+    public function testLoadFilterLikeNot(): void
+    {
+        $rows  = $this->getRows();
+        $model = $this->getModelLoaded($rows);
+
+        $this->assertInstanceOf(PhpArrayModel::class, $model);
+        $this->assertEquals([$rows[2], $rows[3]], $model->load(['b' => [MetaModelInterface::FILTER_CONTAINS_NOT => 'B']]));
+    }
+
+    public function testLoadFilterNot(): void
+    {
+        $rows  = $this->getRows();
+        $model = $this->getModelLoaded($rows);
+
+        $this->assertInstanceOf(PhpArrayModel::class, $model);
+        $this->assertEquals([$rows[0], $rows[2], $rows[3]], $model->load([MetaModelInterface::FILTER_NOT => ['a' => 'A2']]));
+    }
+
     public function testLoadPage1(): void
     {
         $rows  = $this->getRows();


### PR DESCRIPTION
This commit adds general NOT and NOT LIKE functions to the predefined query items in array filters.

It also creates a separate bridge for creating validators, independent of the loading mechanism previously used in Zend_Form.

The new validator bridge alles default variables to be set using interfaces.