### PR TITLE
MetaModel: Check if key is string before doing substring

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,10 +1,10 @@
-name: PHP Model Tests
+name: Static analysis and tests
 
 on:
   push:
-    branches: [ "main", "2.x" ]
+    branches: [ "2.x" ]
   pull_request:
-    branches: [ "main", "2.x" ]
+    branches: [ "2.x" ]
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: COMPOSER_ROOT_VERSION=2.x-dev composer install --prefer-dist --no-progress
 
       - name: Run test suite
         run: composer test
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: COMPOSER_ROOT_VERSION=2.x-dev composer install --prefer-dist --no-progress
 
       - name: Run phpstan
         run: vendor/bin/phpstan --no-progress

--- a/src/MetaModel.php
+++ b/src/MetaModel.php
@@ -1252,7 +1252,7 @@ class MetaModel implements MetaModelInterface
         if ($args) {
             foreach ($args as $key => $value) {
                 // If $key end with ] it is array value
-                if (substr($key, -1) == ']') {
+                if (is_string($key) && substr($key, -1) == ']') {
                     if (substr($key, -2) == '[]') {
                         // If $key ends with [], append it to array
                         $key    = substr($key, 0, -2);


### PR DESCRIPTION
Fixes:
  substr(): Argument #1 ($string) must be of type string, int given