### PR TITLE
Enhance DataReaderInterface with loadPage() function

### DIFF
--- a/src/Data/DataReaderInterface.php
+++ b/src/Data/DataReaderInterface.php
@@ -105,6 +105,18 @@ interface DataReaderInterface extends \Zalt\Model\MetaModellerInterface
     public function loadNew(): array;
 
     /**
+     * Returns the items requested
+     *
+     * @param int $page The page number starting with the offset number ONE, not zero
+     * @param int $items The number of items per page (and thus the number of items returned)
+     * @param mixed $filter Array to use as filter
+     * @param mixed $sort Array to use for sort
+     * @param mixed $columns Array with columns to use (or trackUsage or all)
+     * @return array Nested array or empty
+     */
+    public function loadPage(int $page, int $items, $filter = null, $sort = null, $columns = null): array;
+
+    /**
      * Returns the numbers of rows with the items requested
      *
      * @param int|null $total

--- a/src/Ra/ArrayModelAbstract.php
+++ b/src/Ra/ArrayModelAbstract.php
@@ -384,6 +384,16 @@ abstract class ArrayModelAbstract implements DataReaderInterface
     /**
      * @inheritDoc
      */
+    public function loadPage(int $page, int $items, $filter = null, $sort = null, $columns = null): array
+    {
+        $output = $this->load($filter, $sort);
+
+        return array_slice($output, ($page - 1) * $items, $items);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function loadPageWithCount(?int &$total, int $page, int $items, $filter = null, $sort = null, $columns = null): array
     {
         $output = $this->load($filter, $sort);

--- a/src/Sql/JoinModel.php
+++ b/src/Sql/JoinModel.php
@@ -256,6 +256,18 @@ class JoinModel implements FullDataInterface
         return [];
     }
 
+    public function loadPage(int $page, int $items, $filter = null, $sort = null, $columns = null): array
+    {
+        $joins   = $this->getJoinStore();
+        $columns = $this->sqlRunner->createColumns($this->metaModel, $columns);
+        $where   = $this->sqlRunner->createWhere($this->metaModel, $this->checkFilter($filter));
+        $order   = $this->sqlRunner->createSort($this->metaModel, $this->checkSort($sort));
+
+        return $this->metaModel->processAfterLoad(
+            $this->sqlRunner->fetchRows($joins, $columns, $where, $order, ($page - 1) * $items, $items)
+        );
+    }
+
     public function loadPageWithCount(?int &$total, int $page, int $items, $filter = null, $sort = null, $columns = null): array
     {
         $joins   = $this->getJoinStore();

--- a/src/Sql/Laminas/LaminasSelectModel.php
+++ b/src/Sql/Laminas/LaminasSelectModel.php
@@ -115,6 +115,24 @@ class LaminasSelectModel implements DataReaderInterface
     /**
      * @inheritDoc
      */
+    public function loadPage(int $page, int $items, $filter = null, $sort = null, $columns = null): array
+    {
+        $columns = $this->laminasRunner->createColumns($this->metaModel, $columns);
+        $where   = $this->laminasRunner->createWhere($this->metaModel, $this->checkFilter($filter));
+        $order   = $this->laminasRunner->createSort($this->metaModel, $this->checkSort($sort));
+
+        $selectRows  = clone $this->select;
+        $selectRows->columns($columns);
+        $selectRows->where($where);
+        $selectRows->order($order);
+        $output = $this->laminasRunner->fetchRowsFromSelect($selectRows, ($page - 1) * $items, $items);
+
+        return $this->metaModel->processAfterLoad($output);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function loadPageWithCount(?int &$total, int $page, int $items, $filter = null, $sort = null, $columns = null): array
     {
         $columns = $this->laminasRunner->createColumns($this->metaModel, $columns);

--- a/src/Sql/SqlTableModel.php
+++ b/src/Sql/SqlTableModel.php
@@ -94,6 +94,17 @@ class SqlTableModel implements FullDataInterface
         return [];
     }
 
+    public function loadPage(int $page, int $items, $filter = null, $sort = null, $columns = null): array
+    {
+        $columns = $this->sqlRunner->createColumns($this->metaModel, $columns);
+        $where   = $this->sqlRunner->createWhere($this->metaModel, $this->checkFilter($filter));
+        $order   = $this->sqlRunner->createSort($this->metaModel, $this->checkSort($sort));
+
+        return $this->metaModel->processAfterLoad(
+            $this->sqlRunner->fetchRows($this->tableName, $columns, $where, $order, ($page - 1) * $items, $items)
+        );
+    }
+
     public function loadPageWithCount(?int &$total, int $page, int $items, $filter = null, $sort = null, $columns = null): array
     {
         $columns = $this->sqlRunner->createColumns($this->metaModel, $columns);

--- a/test/Ra/PhpArrayTest.php
+++ b/test/Ra/PhpArrayTest.php
@@ -198,7 +198,7 @@ class PhpArrayTest extends TestCase
         $this->assertEquals($newRow, $model->loadNew());
     }
 
-    public function testLoadPage1(): void
+    public function testLoadPageWithCount1(): void
     {
         $rows  = $this->getRows();
         $model = $this->getModelLoaded($rows);
@@ -215,7 +215,7 @@ class PhpArrayTest extends TestCase
         $this->assertEquals(3, $total);
     }
 
-    public function testLoadPage2(): void
+    public function testLoadPageWithCount2(): void
     {
         $rows  = $this->getRows();
         $model = $this->getModelLoaded($rows);
@@ -230,6 +230,36 @@ class PhpArrayTest extends TestCase
         $this->assertEquals($output, $result);
         $this->assertCount(2, $result);
         $this->assertEquals(4, $total);
+    }
+
+    public function testLoadPage1(): void
+    {
+        $rows  = $this->getRows();
+        $model = $this->getModelLoaded($rows);
+
+        $this->assertInstanceOf(PhpArrayModel::class, $model);
+        $output = [
+            $rows[0],
+            $rows[2],
+        ];
+        $result = $model->loadPage(1, 2, ['c' => [MetaModelInterface::FILTER_BETWEEN_MIN => 10, MetaModelInterface::FILTER_BETWEEN_MAX => 30]]);
+        $this->assertEquals($output, $result);
+        $this->assertCount(2, $result);
+    }
+
+    public function testLoadPage2(): void
+    {
+        $rows  = $this->getRows();
+        $model = $this->getModelLoaded($rows);
+
+        $this->assertInstanceOf(PhpArrayModel::class, $model);
+        $output = [
+            $rows[2],
+            $rows[3],
+        ];
+        $result = $model->loadPage(2, 2);
+        $this->assertEquals($output, $result);
+        $this->assertCount(2, $result);
     }
 
     public function testLoadRepeater(): void


### PR DESCRIPTION
This is a copy of loadPageWithCount() that doesn't count the total number of rows. It is intended to be used on very large tables, to speed up the selection.