### PR TITLE
Bugfix in JsonType when applying to metamodel

### DIFF
--- a/src/Bridge/FormBridgeAbstract.php
+++ b/src/Bridge/FormBridgeAbstract.php
@@ -62,7 +62,7 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
         self::TEXT_OPTIONS       => ['maxlength', 'minlength', 'onblur', 'onchange', 'onfocus', 'onselect', 'size'],
         self::TEXTAREA_OPTIONS   => ['cols', 'decorators', 'rows', 'wrap'],
     ];
-    
+
     protected string $dateTimeClass = "DateTimeInput";
 
     /**
@@ -78,12 +78,12 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
     public MetaModelInterface $metaModel;
 
     public ValidatorBridgeInterface $validatorBridge;
-    
+
     /**
      * @inheritDoc
      */
     public function __construct(protected DataReaderInterface $dataModel)
-    {   
+    {
         if (! $this->dataModel instanceof FullDataInterface) {
             throw new MetaModelException("Only FullDataInterface objects are allowed as input for a FormBridge");
         }
@@ -264,7 +264,7 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
 
         if (isset($options['dateFormat'])) {
             // Make sure the model knows the dateFormat (can be important for storage).
-            $this->metaModel->set($name, 'dateFormat', $options['dateFormat']);
+            $this->metaModel->set($name, ['dateFormat' => $options['dateFormat']]);
         }
 
         return $this->_addToForm($name, $this->dateTimeClass, $options);
@@ -559,7 +559,7 @@ abstract class FormBridgeAbstract implements FormBridgeInterface
         $this->_allowedOptions[$key] = $options;
         return $this;
     }
-    
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
Small bugfix when applying a JsonType on a meta model. The formatter was not given in a callable format.

Fixes following error message:
```
call_user_func(): Argument #1 ($callback) must be a valid callback, function "format" not found or invalid function name
```
