### PR TITLE
LaminasRunner: Support Predicate as field filter

### DIFF
--- a/src/Sql/Laminas/LaminasRunner.php
+++ b/src/Sql/Laminas/LaminasRunner.php
@@ -160,7 +160,9 @@ class LaminasRunner implements \Zalt\Model\Sql\SqlRunnerInterface
                     } else {
                         $name = $field;
                     }
-                    if (is_array($value)) {
+                    if ($value instanceof Predicate) {
+                        $output->addPredicate($value);
+                    } elseif (is_array($value)) {
                         if (1 == count($value)) {
                             if (isset($value[MetaModelInterface::FILTER_CONTAINS])) {
                                 $output->like($name, '%' . $value[MetaModelInterface::FILTER_CONTAINS] . '%');


### PR DESCRIPTION
This makes it possible to construct a Predicate and add that as filter to a specific field.
The reason to add this was that I needed to add a filter to a multi-value organization_id field, where the filter looks like this:

  `gtr_organizations` LIKE '%|50|%' OR `gtr_organizations` LIKE '%|51|%'